### PR TITLE
toggle open files, if necessary

### DIFF
--- a/toggle_sidebar_focus.py
+++ b/toggle_sidebar_focus.py
@@ -2,9 +2,12 @@ import sublime
 import sublime_plugin
 
 class ToggleSidebarAndFocusCommand(sublime_plugin.WindowCommand):
+
     def run(self):
+
         if self.window.is_sidebar_visible():
             self.window.run_command("toggle_side_bar")
+
         else:
             self.window.run_command("toggle_side_bar")
 

--- a/toggle_sidebar_focus.py
+++ b/toggle_sidebar_focus.py
@@ -7,4 +7,10 @@ class ToggleSidebarAndFocusCommand(sublime_plugin.WindowCommand):
             self.window.run_command("toggle_side_bar")
         else:
             self.window.run_command("toggle_side_bar")
+
+            # if it's still not visible, try showing open files
+            if not self.window.is_sidebar_visible():
+                self.window.run_command("toggle_show_open_files")
+                self.window.run_command("toggle_side_bar")
+
             self.window.run_command("focus_side_bar")


### PR DESCRIPTION
On a window without a project, or without any folders associated with it, the sidebar will refuse to toggle when View > Sidebar > "show open files" is toggled off. This change tries to detect that situation and make the necessary toggles so the sidebar will show.